### PR TITLE
Add support for Material Design

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -65,11 +65,6 @@ var Generator = generators.Base.extend({
       return !self.appName;
     };
 
-    // Conditional prompts
-    _.find(prompts, {name: 'ui'}).when = function(props) {
-        return true;
-    };
-
     // Use prompts from json
     this.prompt(prompts, function(props) {
       if (props.target.key === 'mobile') {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -20,12 +20,13 @@ var folderRules = {
   _mobile:    function(props) { return props.target.key !== 'web'; },
   _web:       function(props) { return props.target.key !== 'mobile'; },
   _bootstrap: function(props) { return props.ui.key === 'bootstrap'; },
+  _material:  function(props) { return props.ui.key === 'material'; },
   _ionic:     function(props) { return props.ui.key === 'ionic'; }
 };
 
 var Generator = generators.Base.extend({
 
-  constructor: function() {
+  constructor: function() {   
     generators.Base.apply(this, arguments);
 
     this.argument('appName', {
@@ -66,14 +67,12 @@ var Generator = generators.Base.extend({
 
     // Conditional prompts
     _.find(prompts, {name: 'ui'}).when = function(props) {
-      return props.target.key === 'both';
+        return true;
     };
 
     // Use prompts from json
     this.prompt(prompts, function(props) {
-      if (props.target.key === 'web') {
-        props.ui = {key: 'bootstrap'};
-      } else if (props.target.key === 'mobile') {
+      if (props.target.key === 'mobile') {
         props.ui = {key: 'ionic'};
       }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -26,7 +26,7 @@ var folderRules = {
 
 var Generator = generators.Base.extend({
 
-  constructor: function() {   
+  constructor: function() {
     generators.Base.apply(this, arguments);
 
     this.argument('appName', {

--- a/generators/app/prompts.json
+++ b/generators/app/prompts.json
@@ -42,6 +42,12 @@
       },
       {
         "value": {
+          "key": "material"
+        },
+        "name": "Material Design (web is your main target)"
+      },
+      {
+        "value": {
           "key": "ionic"
         },
         "name": "Ionic (mobile is your main target)"

--- a/generators/app/templates/_bootstrap/sources/modules/shell/shell.html
+++ b/generators/app/templates/_bootstrap/sources/modules/shell/shell.html
@@ -11,7 +11,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="https://github.com/thales-poles-ra/starter-kit/">
+          <a class="navbar-brand" href="https://github.com/angular-starter-kit/starter-kit/">
             <span translate>APP_NAME</span>
           </a>
         </div>

--- a/generators/app/templates/_bower.json
+++ b/generators/app/templates/_bower.json
@@ -14,6 +14,8 @@
     "font-awesome": "~4.5.0",
     "angular-bootstrap": "~1.2.4",
     "bootstrap-sass": "~3.3.6"
+<% } if (props.ui.key === 'material') { -%>
+    "angular-material": "~1.0.7"    
 <% } if (props.ui.key === 'ionic') { -%>
     "ionic": "~1.2.4"
 <% } -%>
@@ -35,6 +37,8 @@
       "main": [],
       "dependencies": []
     }
+  }
+<% } if (props.ui.key === 'material') { -%>
   }
 <% } if (props.ui.key === 'ionic') { -%>
     "ionic": {

--- a/generators/app/templates/_bower.json
+++ b/generators/app/templates/_bower.json
@@ -15,7 +15,8 @@
     "angular-bootstrap": "~1.2.4",
     "bootstrap-sass": "~3.3.6"
 <% } if (props.ui.key === 'material') { -%>
-    "angular-material": "~1.0.7"    
+    "font-awesome": "~4.5.0",
+    "angular-material": "~1.0.7"
 <% } if (props.ui.key === 'ionic') { -%>
     "ionic": "~1.2.4"
 <% } -%>
@@ -36,6 +37,20 @@
     "bootstrap-sass": {
       "main": [],
       "dependencies": []
+    }
+  }
+<% if (props.ui.key === 'material') { -%>
+    "font-awesome": {
+      "main": [
+        "./scss/font-awesome.scss",
+        "./fonts/*"
+      ]
+    },
+    "angular-material": {
+      "main": [
+        "./angular-material.js"
+        "./angular-material.scss"
+      ]
     }
   }
 <% } if (props.ui.key === 'material') { -%>

--- a/generators/app/templates/_material/_tsd.json
+++ b/generators/app/templates/_material/_tsd.json
@@ -1,0 +1,109 @@
+{
+  "version": "v4",
+  "repo": "borisyankov/DefinitelyTyped",
+  "ref": "master",
+  "path": "typings",
+  "bundle": "typings/tsd.d.ts",
+  "installed": {
+    "angularjs/angular.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "angular-ui-router/angular-ui-router.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "angular-gettext/angular-gettext.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "jasmine-jquery/jasmine-jquery.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "jasmine/jasmine.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "angularjs/angular-mocks.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "angularjs/angular-animate.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "angularjs/angular-sanitize.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "jquery/jquery.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "lodash/lodash.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    }<% if (props.target.key !== 'web') { %>,
+    "cordova/cordova.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/BatteryStatus.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Contacts.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Camera.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Dialogs.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Device.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/DeviceOrientation.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/DeviceMotion.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/FileSystem.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/FileTransfer.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Globalization.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Media.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/InAppBrowser.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/MediaCapture.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Splashscreen.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/NetworkInformation.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/StatusBar.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Vibration.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/WebSQL.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Push.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova/plugins/Keyboard.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova-ionic/cordova-ionic.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    },
+    "cordova-ionic/plugins/keyboard.d.ts": {
+      "commit": "41f8573534b0fff88707d0a4cb870456b50cd43b"
+    }
+<% } -%>
+  }
+}

--- a/generators/app/templates/_material/e2e/screens/about.po.js
+++ b/generators/app/templates/_material/e2e/screens/about.po.js
@@ -1,0 +1,12 @@
+/*
+ * This file uses the Page Object pattern to define the main page for tests.
+ * See docs/coding-guide/e2e-tests.md for more info.
+ */
+
+'use strict';
+
+var About = function() {
+  this.jumbotron = element(by.css('.jumbotron'));
+};
+
+module.exports = new About();

--- a/generators/app/templates/_material/e2e/screens/about.spec.js
+++ b/generators/app/templates/_material/e2e/screens/about.spec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+describe('about', function() {
+
+  var page;
+
+  beforeEach(function() {
+    browser.get('/#/about');
+    page = require('./about.po');
+  });
+
+  it('should contain version', function() {
+    expect(page.jumbotron.getText()).toMatch('Version');
+  });
+
+});

--- a/generators/app/templates/_material/e2e/screens/home.po.js
+++ b/generators/app/templates/_material/e2e/screens/home.po.js
@@ -1,0 +1,14 @@
+/*
+ * This file uses the Page Object pattern to define the main page for tests.
+ * See docs/coding-guide/e2e-tests.md for more info.
+ */
+
+'use strict';
+
+var Home = function() {
+  this.jumbotron = element(by.css('.jumbotron'));
+  this.title = this.jumbotron.element(by.css('h1'));
+  this.image = this.jumbotron.element(by.css('img'));
+};
+
+module.exports = new Home();

--- a/generators/app/templates/_material/e2e/screens/home.spec.js
+++ b/generators/app/templates/_material/e2e/screens/home.spec.js
@@ -1,0 +1,17 @@
+'use strict';
+
+describe('home screen', function() {
+
+  var page;
+
+  beforeEach(function() {
+    browser.get('/');
+    page = require('./home.po');
+  });
+
+  it('should include jumbotron with correct data', function() {
+    expect(page.title.getText()).toMatch('Hello');
+    expect(page.image.getAttribute('src')).toMatch('angularjs');
+  });
+
+});

--- a/generators/app/templates/_material/e2e/shell/shell.po.js
+++ b/generators/app/templates/_material/e2e/shell/shell.po.js
@@ -1,0 +1,15 @@
+/*
+ * This file uses the Page Object pattern to define the main page for tests.
+ * See docs/coding-guide/e2e-tests.md for more info.
+ */
+
+'use strict';
+
+var Shell = function() {
+  this.navbar = element(by.css('.navbar'));
+  this.navbarItems = this.navbar.element(by.css('.navbar-nav')).all(by.css('li'));
+  this.languageDropdown = this.navbar.element(by.css('.dropdown'));
+  this.languageDropdownItems = this.languageDropdown.all(by.css('li'));
+};
+
+module.exports = new Shell();

--- a/generators/app/templates/_material/e2e/shell/shell.spec.js
+++ b/generators/app/templates/_material/e2e/shell/shell.spec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+describe('shell', function() {
+
+  var page;
+
+  beforeEach(function() {
+    browser.get('/');
+    page = require('./shell.po');
+  });
+
+  it('header should contain 2 links', function() {
+    expect(page.navbarItems.count()).toBe(2);
+  });
+
+  it('dropdown should contain 2 supported languages', function() {
+    expect(page.languageDropdownItems.count()).toBe(2);
+  });
+
+});

--- a/generators/app/templates/_material/sources/_index.html
+++ b/generators/app/templates/_material/sources/_index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html ng-app="app">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title ng-bind="pageTitle"></title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width">
+<% if (props.target.key !== 'web') { -%>
+    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+<% } -%>
+    <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
+    <!-- build:css(sources) styles/vendor.css -->
+    <!-- bower:css -->
+    <!-- endbower -->
+    <!-- endbuild -->
+
+    <!-- build:css(.tmp) styles/app.css -->
+    <!-- inject:css -->
+    <!-- endinject -->
+    <!-- endbuild -->
+  </head>
+  <body>
+<% if (props.target.key !== 'web') { -%>
+    <!-- Include Cordova script only when needed -->
+    <script>
+      (function() {
+        if (!/^http/.test(location.protocol)) {
+          var c = document.createElement('script');
+          c.setAttribute('src', 'cordova.js');
+          document.body.appendChild(c);
+        }
+      })();
+    </script>
+
+<% } -%>
+    <!--[if lt IE 10]>
+    <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your
+      experience.</p>
+    <![endif]-->
+
+    <div ui-view></div>
+
+    <!-- build:js(sources) scripts/vendor.js -->
+    <!-- bower:js -->
+    <!-- endbower -->
+    <!-- endbuild -->
+
+    <!-- build:js({.tmp/partials,sources,.tmp}) scripts/app.js -->
+    <!-- inject:js -->
+    <!-- endinject -->
+    <!-- endbuild -->
+  </body>
+</html>

--- a/generators/app/templates/_material/sources/main/_main.module.ts
+++ b/generators/app/templates/_material/sources/main/_main.module.ts
@@ -1,0 +1,19 @@
+/// <reference path="../../typings/tsd.d.ts" />
+
+module app {
+
+  'use strict';
+
+  angular.module('app', [
+    'app.additions',
+    'gettext',
+    'ngAnimate',
+    'ngSanitize',
+<% if (props.target.key !== 'web') { -%>
+    'ngCordova',
+<% } -%>
+    'ui.router',
+    'ngMaterial'
+  ]);
+
+}

--- a/generators/app/templates/_material/sources/main/_main.run.ts
+++ b/generators/app/templates/_material/sources/main/_main.run.ts
@@ -1,0 +1,151 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Entry point of the application.
+   * Initializes application and root controller.
+   */
+  function main($window: ng.IWindowService,
+                $locale: ng.ILocaleService,
+                $rootScope: any,
+                $state: angular.ui.IStateService,
+<% if (props.target.key !== 'web') { -%>
+                $timeout: ng.ITimeoutService,
+                $cordovaKeyboard: any,
+<% } -%>
+                gettextCatalog: angular.gettext.gettextCatalog,
+                _: _.LoDashStatic,
+                config: any,
+<% if (props.target.key !== 'web') { -%>
+                logger: LoggerService,
+<% } -%>
+                restService: RestService) {
+
+    /*
+     * Root view model
+     */
+
+    let vm = $rootScope;
+
+    vm.pageTitle = '';
+
+    /**
+     * Utility method to set the language in the tools requiring it.
+     * The current language is saved to the local storage.
+     * If no parameter is specified, the language is loaded from local storage (if possible).
+     * @param {string=} language The IETF language tag.
+     */
+    vm.setLanguage = function(language?: string) {
+      language = language || $window.localStorage.getItem('language');
+      let isSupportedLanguage = _.includes(config.supportedLanguages, language);
+
+<% if (props.target.key !== 'web') { -%>
+      // If no exact match is found, search without the region
+      if (!isSupportedLanguage && language) {
+        let languagePart = language.split('-')[0];
+        language = _.find(config.supportedLanguages,
+          (supportedLanguage: string) => _.startsWith(supportedLanguage, languagePart));
+        isSupportedLanguage = !!language;
+      }
+<% } -%>
+
+        // Fallback if language is not supported
+      if (!isSupportedLanguage) {
+        language = 'en-US';
+      }
+
+      // Configure translation with gettext
+      gettextCatalog.setCurrentLanguage(language);
+      $locale.id = language;
+      $window.localStorage.setItem('language', language);
+    };
+
+    /**
+     * Updates page title on view change.
+     */
+    vm.$on('$stateChangeSuccess', (event: any, toState: angular.ui.IState) => {
+      updatePageTitle(toState.data ? toState.data.title : null);
+    });
+
+    /**
+     * Updates page title on language change.
+     */
+    vm.$on('gettextLanguageChanged', () => {
+      updatePageTitle($state.current.data ? $state.current.data.title : null);
+    });
+
+    init();
+
+    /*
+     * Internal
+     */
+
+    /**
+     * Initializes the root controller.
+     */
+    function init() {
+<% if (props.target.key !== 'web') { -%>
+      let _logger: ILogger = logger.getLogger('main');
+<% } -%>
+      // Enable debug mode for translations
+      gettextCatalog.debug = config.debug;
+
+      vm.setLanguage();
+
+      // Set REST server configuration
+<% if (props.target.key === 'web') { -%>
+      restService.setServer(config.server);
+<% } else { -%>
+      restService.setServer(config.debug ? config.server.development : config.server.production);
+
+      // Cordova platform and plugins init
+      $window.document.addEventListener('deviceready', function() {
+
+        // Hide splash screen
+        var splashScreen = $window.navigator.splashscreen;
+        if (splashScreen) {
+          $timeout(() => {
+            splashScreen.hide();
+          }, 1000);
+        }
+
+        // Detect and set default language
+        let globalization = $window.navigator.globalization;
+        if (globalization) {
+          // Use cordova plugin to retrieve device's locale
+          globalization.getPreferredLanguage((language) => {
+            _logger.log('Setting device locale "' + language.value + '" as default language');
+            vm.$apply(function() {
+              vm.setLanguage(language.value);
+            });
+          }, null);
+        }
+
+        if ($window.cordova && $window.cordova.plugins.Keyboard) {
+          $cordovaKeyboard.disableScroll(true);
+        }
+
+      }, false);
+<% } -%>
+    }
+
+    /**
+     * Updates the page title.
+     * @param {?string=} stateTitle Title of current state, to be translated.
+     */
+    function updatePageTitle(stateTitle?: string) {
+      vm.pageTitle = gettextCatalog.getString('APP_NAME');
+
+      if (stateTitle) {
+        vm.pageTitle += ' | ' + gettextCatalog.getString(stateTitle);
+      }
+    }
+
+  }
+
+  angular
+    .module('app')
+    .run(main);
+
+}

--- a/generators/app/templates/_material/sources/main/main.routes.ts
+++ b/generators/app/templates/_material/sources/main/main.routes.ts
@@ -1,0 +1,39 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Configures the application routes.
+   */
+  function routeConfig($stateProvider: angular.ui.IStateProvider,
+                       $urlRouterProvider: angular.ui.IUrlRouterProvider,
+                       gettext: angular.gettext.gettextFunction) {
+
+    // Routes configuration
+    $urlRouterProvider.otherwise('/');
+
+    $stateProvider
+      .state('app', {
+        templateUrl: 'modules/shell/shell.html',
+        controller: 'shellController as shell'
+      })
+      .state('app.home', {
+        url: '/',
+        templateUrl: 'modules/screens/home/home.html',
+        controller: 'homeController as vm',
+        data: {title: gettext('Home')}
+      })
+      .state('app.about', {
+        url: '/about',
+        templateUrl: 'modules/screens/about/about.html',
+        controller: 'aboutController as vm',
+        data: {title: gettext('About')}
+      });
+
+  }
+
+  angular
+    .module('app')
+    .config(routeConfig);
+
+}

--- a/generators/app/templates/_material/sources/main/main.scss
+++ b/generators/app/templates/_material/sources/main/main.scss
@@ -7,7 +7,7 @@
 // bower:scss
 // endbower
 
-// Bootstrap and theme customization
+// Theme customization
 @import "theme/theme";
 
 // Global styling

--- a/generators/app/templates/_material/sources/main/main.scss
+++ b/generators/app/templates/_material/sources/main/main.scss
@@ -1,0 +1,20 @@
+/*
+ * Entry point of application style.
+ */
+
+// Do not remove this comments bellow. It's the markers used by wiredep to inject
+// style dependencies when defined in the bower.json of your dependencies.
+// bower:scss
+// endbower
+
+// Bootstrap and theme customization
+@import "theme/theme";
+
+// Global styling
+@import "hacks";
+@import "helpers";
+
+// Do not remove the comments below. It's the markers used by gulp-inject to inject all your style files
+// from /modules folder automatically.
+// inject:styles
+// endinject

--- a/generators/app/templates/_material/sources/main/theme/theme.scss
+++ b/generators/app/templates/_material/sources/main/theme/theme.scss
@@ -1,0 +1,4 @@
+/*
+ * Global application theme.
+ * Framework overrides and customization goes here.
+ */

--- a/generators/app/templates/_material/sources/modules/screens/about/about.controller.ts
+++ b/generators/app/templates/_material/sources/modules/screens/about/about.controller.ts
@@ -1,0 +1,29 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Displays the about screen.
+   */
+  export class AboutController {
+
+    version: string;
+
+    private logger: ILogger;
+
+    constructor(logger: LoggerService,
+                config: any) {
+
+      this.logger = logger.getLogger('about');
+      this.version = config.version;
+
+      this.logger.log('init');
+    }
+
+  }
+
+  angular
+    .module('app')
+    .controller('aboutController', AboutController);
+
+}

--- a/generators/app/templates/_material/sources/modules/screens/about/about.html
+++ b/generators/app/templates/_material/sources/modules/screens/about/about.html
@@ -3,7 +3,7 @@
     <md-card>
       <md-card-title>
         <md-card-title-text>
-          <span class="md-headline">APP_NAME</span>          
+          <span class="md-headline" translate>APP_NAME</span>          
           <p>
             <span translate>Version</span> {{vm.version}}
           </p>

--- a/generators/app/templates/_material/sources/modules/screens/about/about.html
+++ b/generators/app/templates/_material/sources/modules/screens/about/about.html
@@ -1,0 +1,18 @@
+<section id="about-screen">
+  <div class="jumbotron text-center">    
+    <md-card>
+      <md-card-title>
+        <md-card-title-text>
+          <span class="md-headline">APP_NAME</span>          
+          <p>
+            <span translate>Version</span> {{vm.version}}
+          </p>
+        </md-card-title-text>
+        <md-card-title-media>                       
+        </md-card-title-media>
+      </md-card-title>
+      <md-card-actions layout="row" layout-align="end center">        
+      </md-card-actions>
+    </md-card>
+  </div>
+</section>

--- a/generators/app/templates/_material/sources/modules/screens/home/home.controller.ts
+++ b/generators/app/templates/_material/sources/modules/screens/home/home.controller.ts
@@ -1,0 +1,40 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Displays the home screen.
+   */
+  export class HomeController {
+
+    isLoading: boolean = true;
+    quote: string = null;
+
+    private logger: ILogger;
+    private quoteService: QuoteService;
+
+    constructor(logger: LoggerService,
+                quoteService: QuoteService) {
+
+      this.logger = logger.getLogger('home');
+      this.quoteService = quoteService;
+
+      this.logger.log('init');
+
+      this.quoteService
+        .getRandomJoke({category: 'nerdy'})
+        .then((quote: string) => {
+          this.quote = quote;
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
+    }
+
+  }
+
+  angular
+    .module('app')
+    .controller('homeController', HomeController);
+
+}

--- a/generators/app/templates/_material/sources/modules/screens/home/home.html
+++ b/generators/app/templates/_material/sources/modules/screens/home/home.html
@@ -3,8 +3,8 @@
     <md-card>
         <md-card-title>
           <md-card-title-text>
-            <span class="md-headline">Hello</span>
-            <span class="md-subhead">Material Design World !</span>
+            <span class="md-headline" translate>Hello</span>
+            <span class="md-subhead" translate>Material Design World !</span>
             <p>
                 <em class="quote">{{vm.quote}}</em>
             </p>
@@ -14,7 +14,7 @@
           </md-card-title-media>
         </md-card-title>
         <md-card-actions layout="row" layout-align="end center">
-          <md-button class="md-primary" ng-href="https://material.angularjs.org/latest/demo">Read more about Material Design</md-button>
+          <md-button class="md-primary" ng-href="https://material.angularjs.org/latest/demo" translate>Read more about Material Design</md-button>
         </md-card-actions>
       </md-card>
     <div ui-loading="vm.isLoading"></div>

--- a/generators/app/templates/_material/sources/modules/screens/home/home.html
+++ b/generators/app/templates/_material/sources/modules/screens/home/home.html
@@ -1,0 +1,23 @@
+<section id="home-screen" class="home-screen container-fluid">
+  <div class="jumbotron text-center">
+    <md-card>
+        <md-card-title>
+          <md-card-title-text>
+            <span class="md-headline">Hello</span>
+            <span class="md-subhead">Material Design World !</span>
+            <p>
+                <em class="quote">{{vm.quote}}</em>
+            </p>
+          </md-card-title-text>
+          <md-card-title-media>            
+            <img class="logo" src="images/angularjs-logo.png" alt="angularjs logo"/> 
+          </md-card-title-media>
+        </md-card-title>
+        <md-card-actions layout="row" layout-align="end center">
+          <md-button class="md-primary" ng-href="https://material.angularjs.org/latest/demo">Read more about Material Design</md-button>
+        </md-card-actions>
+      </md-card>
+    <div ui-loading="vm.isLoading"></div>
+  </div>  
+</div>
+</section>

--- a/generators/app/templates/_material/sources/modules/screens/home/home.scss
+++ b/generators/app/templates/_material/sources/modules/screens/home/home.scss
@@ -1,0 +1,9 @@
+// Encapsulate component style into its own "namespace "to avoid naming and css collision
+.home-screen {
+
+  .logo {
+    max-height: 100px;
+    width: auto;
+  }
+
+}

--- a/generators/app/templates/_material/sources/modules/shell/shell.controller.ts
+++ b/generators/app/templates/_material/sources/modules/shell/shell.controller.ts
@@ -1,0 +1,52 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Displays the SPA shell.
+   * The shell contains the shared parts of the application: header, footer, navigation...
+   */
+  export class ShellController {
+
+    languages: any;
+    currentLocale: ng.ILocaleService;
+    menuHidden: boolean;
+
+    private logger: ILogger;
+
+    constructor(private $state: ng.ui.IStateService,
+                $locale: ng.ILocaleService,
+                logger: LoggerService,
+                config: any) {
+
+      this.currentLocale = $locale;
+      this.logger = logger.getLogger('shell');
+      this.languages = config.supportedLanguages;
+      this.menuHidden = true;
+
+      this.logger.log('init');
+    }
+
+    /**
+     * Toggles navigation menu visibility on mobile platforms.
+     */
+    toggleMenu() {
+      this.menuHidden = !this.menuHidden;
+    }
+
+    /**
+     * Checks if the specified state name is the current.
+     * @param {string} name The state name to check.
+     * @return {boolean} True if the specified state name is the current.
+     */
+    stateContains(name: string): boolean {
+      return this.$state.current.name === name;
+    }
+
+  }
+
+  angular
+    .module('app')
+    .controller('shellController', ShellController);
+
+}

--- a/generators/app/templates/_material/sources/modules/shell/shell.html
+++ b/generators/app/templates/_material/sources/modules/shell/shell.html
@@ -1,0 +1,32 @@
+<section id="shell" class="shell">
+
+    <!-- Header -->
+    <header>
+        <div layout="row" layout-padding layout-align="space-between center">
+            <div>
+                <md-button ng-href="https://github.com/angular-starter-kit/starter-kit/">
+                    <span translate>APP_NAME</span>
+                </md-button>
+                <md-button ng-class="{ 'md-primary': shell.stateContains('app.home') }" ui-sref="app.home">
+                    <span translate>Home</span>
+                </md-button>
+                <md-button ng-class="{ 'md-primary': shell.stateContains('app.about') }" ui-sref="app.about">
+                    <span translate>About</span>
+                </md-button>                                                
+            </div>
+            <div class="nav-buttons">
+                <md-menu>
+                    <md-button md-menu-origin ng-click="$mdOpenMenu()">{{shell.currentLocale.id}}</md-button>
+                    <md-menu-content width="2">
+                        <md-menu-item ng-repeat="language in ::shell.languages">                            
+                            <md-button ng-click="setLanguage(language)">{{language}}</md-button>
+                        </md-menu-item>                        
+                    </md-menu-content>
+                </md-menu>
+            </div>
+    </header>
+
+    <!-- View content -->
+    <div ui-view></div>
+
+</section>

--- a/generators/app/templates/_material/sources/modules/shell/shell.html
+++ b/generators/app/templates/_material/sources/modules/shell/shell.html
@@ -1,32 +1,32 @@
 <section id="shell" class="shell">
 
-    <!-- Header -->
-    <header>
-        <div layout="row" layout-padding layout-align="space-between center">
-            <div>
-                <md-button ng-href="https://github.com/angular-starter-kit/starter-kit/">
-                    <span translate>APP_NAME</span>
-                </md-button>
-                <md-button ng-class="{ 'md-primary': shell.stateContains('app.home') }" ui-sref="app.home">
-                    <span translate>Home</span>
-                </md-button>
-                <md-button ng-class="{ 'md-primary': shell.stateContains('app.about') }" ui-sref="app.about">
-                    <span translate>About</span>
-                </md-button>                                                
-            </div>
-            <div class="nav-buttons">
-                <md-menu>
-                    <md-button md-menu-origin ng-click="$mdOpenMenu()">{{shell.currentLocale.id}}</md-button>
-                    <md-menu-content width="2">
-                        <md-menu-item ng-repeat="language in ::shell.languages">                            
-                            <md-button ng-click="setLanguage(language)">{{language}}</md-button>
-                        </md-menu-item>                        
-                    </md-menu-content>
-                </md-menu>
-            </div>
-    </header>
+  <!-- Header -->
+  <header>
+    <div layout="row" layout-padding layout-align="space-between center">
+      <div>
+        <md-button ng-href="https://github.com/angular-starter-kit/starter-kit/">
+          <span translate>APP_NAME</span>
+        </md-button>
+        <md-button ng-class="{ 'md-primary': shell.stateContains('app.home') }" ui-sref="app.home">
+          <span translate>Home</span>
+        </md-button>
+        <md-button ng-class="{ 'md-primary': shell.stateContains('app.about') }" ui-sref="app.about">
+          <span translate>About</span>
+        </md-button>
+      </div>
+      <div class="nav-buttons">
+        <md-menu>
+          <md-button md-menu-origin ng-click="$mdOpenMenu()">{{shell.currentLocale.id}}</md-button>
+          <md-menu-content width="2">
+            <md-menu-item ng-repeat="language in ::shell.languages">
+              <md-button ng-click="setLanguage(language)">{{language}}</md-button>
+            </md-menu-item>
+          </md-menu-content>
+        </md-menu>
+      </div>
+  </header>
 
-    <!-- View content -->
-    <div ui-view></div>
+  <!-- View content -->
+  <div ui-view></div>
 
 </section>

--- a/generators/app/templates/_material/sources/modules/shell/shell.scss
+++ b/generators/app/templates/_material/sources/modules/shell/shell.scss
@@ -1,0 +1,12 @@
+// Encapsulate component style into its own "namespace "to avoid naming and css collision
+.shell {
+
+  .jumbotron {
+    min-height: 500px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+  }
+
+}

--- a/generators/app/templates/_material/sources/modules/ui-components/loading/loading.directive.spec.js
+++ b/generators/app/templates/_material/sources/modules/ui-components/loading/loading.directive.spec.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/*
+ * Tests for loading directive.
+ */
+describe('loading directive', function() {
+
+  var $rootScope;
+  var $compile;
+  var element;
+
+  beforeEach(function() {
+    module('templateCache');
+    module('app');
+
+    inject(function(_$rootScope_,
+                    _$compile_) {
+
+      $rootScope = _$rootScope_;
+      $compile = _$compile_;
+    });
+
+    element = $('<div ui-loading="isLoading"></div>');
+    element = $compile(element)($rootScope);
+    $rootScope.$digest();
+  });
+
+  it('should be visible only when loading is in progress', function() {
+
+    var div = element.children().eq(0);
+
+    $rootScope.isLoading = true;
+    $rootScope.$digest();
+
+    expect(div).not.toHaveClass('ng-hide');
+
+    $rootScope.isLoading = false;
+    $rootScope.$digest();
+
+    expect(div).toHaveClass('ng-hide');
+
+  });
+
+});

--- a/generators/app/templates/_material/sources/modules/ui-components/loading/loading.directive.ts
+++ b/generators/app/templates/_material/sources/modules/ui-components/loading/loading.directive.ts
@@ -1,0 +1,30 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Loading directive: displays a loading indicator while data is being loaded.
+   *
+   * Example usage: <div ui-loading="isLoading"></div>
+   * The expected value of the directive attribute is a boolean indicating whether the content
+   * is still loading or not.
+   *
+   * Additional parameter attributes:
+   * - message: the loading message to display (none by default)
+   *
+   * Example: <div ui-loading="isLoading" message="Loading..."></div>
+   */
+  export class LoadingDirective implements ng.IDirective {
+    restrict = 'A';
+    templateUrl = 'modules/ui-components/loading/loading.html';
+    scope = {
+      message: '<',
+      isLoading: '<uiLoading'
+    };
+  }
+
+  angular
+    .module('app')
+    .directive('uiLoading', () => new LoadingDirective());
+
+}

--- a/generators/app/templates/_material/sources/modules/ui-components/loading/loading.html
+++ b/generators/app/templates/_material/sources/modules/ui-components/loading/loading.html
@@ -1,0 +1,3 @@
+<div ng-show="isLoading" class="text-center">
+  <i class="fa fa-cog fa-spin fa-3x"></i> <span>{{message}}</span>
+</div>

--- a/generators/app/templates/_material/sources/translations/_en-US.po
+++ b/generators/app/templates/_material/sources/translations/_en-US.po
@@ -1,0 +1,34 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: en-US\n"
+
+#: main.routes.js:34
+#: modules/shell/shell.html:29
+msgid "About"
+msgstr "About"
+
+#: main.run.js:84
+#: modules/screens/about/about.html:3
+#: modules/shell/shell.html:15
+msgid "APP_NAME"
+msgstr "<%= props.appName || 'Awesome App' %>"
+
+#: modules/screens/home/home.html:5
+msgid "Hello world !"
+msgstr "Hello world !"
+
+#: main.routes.js:28
+#: modules/shell/shell.html:23
+msgid "Home"
+msgstr "Home"
+
+#: modules/shell/shell.html:9
+msgid "Toggle navigation"
+msgstr "Toggle navigation"
+
+#: modules/screens/about/about.html:5
+msgid "Version"
+msgstr "Version"

--- a/generators/app/templates/_material/sources/translations/_en-US.po
+++ b/generators/app/templates/_material/sources/translations/_en-US.po
@@ -32,3 +32,11 @@ msgstr "Toggle navigation"
 #: modules/screens/about/about.html:5
 msgid "Version"
 msgstr "Version"
+
+#: modules\screens\home\home.html:7
+msgid "Material Design World !"
+msgstr "Material Design World !"
+
+#: modules\screens\home\home.html:17
+msgid "Read more about Material Design"
+msgstr "Read more about Material Design"

--- a/generators/app/templates/_material/sources/translations/_fr-FR.po
+++ b/generators/app/templates/_material/sources/translations/_fr-FR.po
@@ -32,3 +32,11 @@ msgstr "Basculer la navigation"
 #: modules/screens/about/about.html:5
 msgid "Version"
 msgstr "Version"
+
+#: modules\screens\home\home.html:7
+msgid "Material Design World !"
+msgstr "le Monde Material Design !"
+
+#: modules\screens\home\home.html:17
+msgid "Read more about Material Design"
+msgstr "En savoir plus sur Material Design"

--- a/generators/app/templates/_material/sources/translations/_fr-FR.po
+++ b/generators/app/templates/_material/sources/translations/_fr-FR.po
@@ -1,0 +1,34 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fr-FR\n"
+
+#: main.routes.js:34
+#: modules/shell/shell.html:29
+msgid "About"
+msgstr "A propos"
+
+#: main.run.js:84
+#: modules/screens/about/about.html:3
+#: modules/shell/shell.html:15
+msgid "APP_NAME"
+msgstr "<%= props.appName || 'Awesome App' %>"
+
+#: modules/screens/home/home.html:5
+msgid "Hello world !"
+msgstr "Bonjour le monde !"
+
+#: main.routes.js:28
+#: modules/shell/shell.html:23
+msgid "Home"
+msgstr "Accueil"
+
+#: modules/shell/shell.html:9
+msgid "Toggle navigation"
+msgstr "Basculer la navigation"
+
+#: modules/screens/about/about.html:5
+msgid "Version"
+msgstr "Version"


### PR DESCRIPTION
This is my first try add support for [Material Design](https://material.angularjs.org) in the generator.

I used the following approach:
- update prompts.json to add a new option to select Material Design as a UI framework
- update index.js yeoman file to enable selection of the new option instead of automatically selecting Bootstrap as the UI framework when target is 'web'

Then the appropriate files in the _material source folder. It's mostly a copy/paste from the bootstrap version. I only had to change shell.html, home.html and about.html.

That makes me think the structure of the _material, _bootstrap and _ionic folder could be overhaul to have less copy/paste of the same content (typically controllers could be reused) but I let this door open for a future PR ;-)

Obligatory screenshot:

![image](https://cloud.githubusercontent.com/assets/2237018/14288815/999261fa-fb58-11e5-9ec1-4d53ad4d0978.png)

Looking forward reading your thoughts about this.
