### PR TITLE
Remove 'use strict' statement as of TypeScript 1.8 it's no longer needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 sample/
+.vscode/
 .idea/
 .npm-debug.log
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "editor.tabSize": 2,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "editor.tabSize": 2,
-}

--- a/generators/app/templates/_bootstrap/sources/main/_main.module.ts
+++ b/generators/app/templates/_bootstrap/sources/main/_main.module.ts
@@ -2,8 +2,6 @@
 
 module app {
 
-  'use strict';
-
   angular.module('app', [
     'app.additions',
     'gettext',

--- a/generators/app/templates/_bootstrap/sources/main/main.routes.ts
+++ b/generators/app/templates/_bootstrap/sources/main/main.routes.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Configures the application routes.
    */

--- a/generators/app/templates/_bootstrap/sources/modules/screens/about/about.controller.ts
+++ b/generators/app/templates/_bootstrap/sources/modules/screens/about/about.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the about screen.
    */

--- a/generators/app/templates/_bootstrap/sources/modules/screens/home/home.controller.ts
+++ b/generators/app/templates/_bootstrap/sources/modules/screens/home/home.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the home screen.
    */

--- a/generators/app/templates/_bootstrap/sources/modules/shell/shell.controller.ts
+++ b/generators/app/templates/_bootstrap/sources/modules/shell/shell.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the SPA shell.
    * The shell contains the shared parts of the application: header, footer, navigation...

--- a/generators/app/templates/_bootstrap/sources/modules/ui-components/loading/loading.directive.ts
+++ b/generators/app/templates/_bootstrap/sources/modules/ui-components/loading/loading.directive.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Loading directive: displays a loading indicator while data is being loaded.
    *

--- a/generators/app/templates/_ionic/sources/main/main.module.ts
+++ b/generators/app/templates/_ionic/sources/main/main.module.ts
@@ -2,8 +2,6 @@
 
 module app {
 
-  'use strict';
-
   angular.module('app', [
     'app.additions',
     'ionic',

--- a/generators/app/templates/_ionic/sources/main/main.routes.ts
+++ b/generators/app/templates/_ionic/sources/main/main.routes.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Configures the application routes.
    */

--- a/generators/app/templates/_ionic/sources/modules/screens/about/about.controller.ts
+++ b/generators/app/templates/_ionic/sources/modules/screens/about/about.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the about screen.
    */

--- a/generators/app/templates/_ionic/sources/modules/screens/home/home.controller.ts
+++ b/generators/app/templates/_ionic/sources/modules/screens/home/home.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the home screen.
    */

--- a/generators/app/templates/_ionic/sources/modules/shell/shell.controller.ts
+++ b/generators/app/templates/_ionic/sources/modules/shell/shell.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the SPA shell.
    * The shell contains the shared parts of the application: header, footer, navigation...

--- a/generators/app/templates/_ionic/sources/modules/ui-components/loading/loading.directive.ts
+++ b/generators/app/templates/_ionic/sources/modules/ui-components/loading/loading.directive.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Loading directive: displays a loading indicator while data is being loaded.
    *

--- a/generators/app/templates/_material/sources/main/_main.module.ts
+++ b/generators/app/templates/_material/sources/main/_main.module.ts
@@ -2,8 +2,6 @@
 
 module app {
 
-  'use strict';
-
   angular.module('app', [
     'app.additions',
     'gettext',

--- a/generators/app/templates/_material/sources/main/main.routes.ts
+++ b/generators/app/templates/_material/sources/main/main.routes.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Configures the application routes.
    */

--- a/generators/app/templates/_material/sources/modules/screens/about/about.controller.ts
+++ b/generators/app/templates/_material/sources/modules/screens/about/about.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the about screen.
    */

--- a/generators/app/templates/_material/sources/modules/screens/home/home.controller.ts
+++ b/generators/app/templates/_material/sources/modules/screens/home/home.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the home screen.
    */

--- a/generators/app/templates/_material/sources/modules/shell/shell.controller.ts
+++ b/generators/app/templates/_material/sources/modules/shell/shell.controller.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Displays the SPA shell.
    * The shell contains the shared parts of the application: header, footer, navigation...

--- a/generators/app/templates/_material/sources/modules/ui-components/loading/loading.directive.ts
+++ b/generators/app/templates/_material/sources/modules/ui-components/loading/loading.directive.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Loading directive: displays a loading indicator while data is being loaded.
    *

--- a/generators/app/templates/sources/main/_main.constants.ts
+++ b/generators/app/templates/sources/main/_main.constants.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   // Do not remove the comments below, or change the values. It's the markers used by gulp build task to change the
   // value of the config constant when building the application, while removing the code below for all environments.
   // replace:environment

--- a/generators/app/templates/sources/main/_main.run.ts
+++ b/generators/app/templates/sources/main/_main.run.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Entry point of the application.
    * Initializes application and root controller.

--- a/generators/app/templates/sources/main/main.config.ts
+++ b/generators/app/templates/sources/main/main.config.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Configures the application (before running).
    */

--- a/generators/app/templates/sources/main/main.wrappers.ts
+++ b/generators/app/templates/sources/main/main.wrappers.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Wraps external global libraries into AngularJS injection system.
    * global window: false

--- a/generators/app/templates/sources/modules/helpers/cache/cache.service.ts
+++ b/generators/app/templates/sources/modules/helpers/cache/cache.service.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   export interface ICacheData {
     date: Date;
     data: any;

--- a/generators/app/templates/sources/modules/helpers/context/context.service.ts
+++ b/generators/app/templates/sources/modules/helpers/context/context.service.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Context service: provides URL context injection based on specified context.
    */

--- a/generators/app/templates/sources/modules/helpers/logger/logger.ts
+++ b/generators/app/templates/sources/modules/helpers/logger/logger.ts
@@ -32,8 +32,6 @@
  */
 module app {
 
-  'use strict';
-
   let observers: Array<Function> = [];
 
   /**

--- a/generators/app/templates/sources/modules/helpers/rest/rest.service.ts
+++ b/generators/app/templates/sources/modules/helpers/rest/rest.service.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   export interface IServerConfig {
     url: string;
     route: string;

--- a/generators/app/templates/sources/modules/web-services/quote/quote.service.ts
+++ b/generators/app/templates/sources/modules/web-services/quote/quote.service.ts
@@ -1,7 +1,5 @@
 module app {
 
-  'use strict';
-
   /**
    * Quote service: allows to get quote of the day.
    */


### PR DESCRIPTION
Starting with TypeScript 1.8, 'use strict' statement are automatically generated: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes

We therefore no longer need them in the source files.

Bonus: update .gitignore to ignore Visual Studio code settings folder
