### PR TITLE
Made protractor tests working on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ node_js:
   - stable
 
 matrix:
-  fast_finish: true
+  - fast_finish: true
+  # Only in the meantime npm packages get updated for node v6
+  - allow_failures:
+      node_js:
+        stable
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 git:
   depth: 1
 
@@ -21,8 +21,8 @@ install:
   - npm link
 
 before_script:
-  # For protractor tests
-  - export CHROME_BIN=chromium-browser
+  # For protractor tests (chrome is not installed on travis)
+  - export PROTRACTOR_BROWSER='firefox'
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ node_js:
   - stable
 
 matrix:
-  - fast_finish: true
+  fast_finish: true
   # Only in the meantime npm packages get updated for node v6
-  - allow_failures:
-      node_js:
-        stable
+  allow_failures:
+    - node_js: stable
 
 env:
   global:

--- a/generators/app/templates/protractor.conf.js
+++ b/generators/app/templates/protractor.conf.js
@@ -12,7 +12,7 @@ exports.config = {
 
   // Capabilities to be passed to the webdriver instance.
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': process.env.PROTRACTOR_BROWSER || 'chrome'
   },
 
   framework: 'jasmine2',

--- a/scripts/test-generator.sh
+++ b/scripts/test-generator.sh
@@ -42,9 +42,8 @@ do
     yo angular-pro --automate "$CWD/$file" $TEST_APP_NAME
 
     gulp test
-#    gulp clean && gulp protractor
-#    gulp clean && gulp protractor:dist
-    gulp clean && gulp build
+    gulp clean && gulp protractor
+    gulp clean && gulp protractor:dist
 
     mv node_modules $CACHE_FOLDER
 


### PR DESCRIPTION
Protractor tests were disabled in travis due to chrome-driver crashing.
The Travis script has been modified to use firefox, which works.

As a temp fix for issues with node v6, latest node version is allowed to fail, only in the meantime the packages get updated.
