### PR TITLE
Google Analytics helper

### DIFF
--- a/generators/app/templates/sources/main/_main.constants.ts
+++ b/generators/app/templates/sources/main/_main.constants.ts
@@ -5,7 +5,7 @@ export interface IApplicationConfig {
   version: string;
   environment: IApplicationEnvironment;
   supportedLanguages: Array<string>;
-  analyticsAccount: string;
+  googleAnayticsId: string;
 }
 
 export interface IApplicationEnvironment {
@@ -59,9 +59,9 @@ let config: IApplicationConfig = {
     'fr-FR'
   ],
 
-  // Google Analytics account. Leave null to not have any analytics active.
-  // Typical values take the form 'UA-########-1'.
-  analyticsAccount: null
+  // Google Analytics account. Leave null to not have any analytics active. Typical values take the form 'UA-########-1'.
+  // You can use something along the lines of < this.environment.debug ? null : 'UA-########-1' >
+  googleAnayticsId: null
 
 };
 

--- a/generators/app/templates/sources/main/_main.constants.ts
+++ b/generators/app/templates/sources/main/_main.constants.ts
@@ -5,11 +5,11 @@ export interface IApplicationConfig {
   version: string;
   environment: IApplicationEnvironment;
   supportedLanguages: Array<string>;
-  googleAnayticsId: string;
 }
 
 export interface IApplicationEnvironment {
   debug: boolean;
+  googleAnayticsId: string;
   server: IServerConfig;
 }
 
@@ -20,6 +20,10 @@ let environment = {
   local: {
     debug: true,
 
+    // Google Analytics account. Leave null to not have any analytics active.
+    // Typical values are of the form 'UA-########-1', where each # is a digit.
+    googleAnayticsId: null,
+
     // REST backend configuration, used for all web services using restService
     server: {
       url: '',
@@ -28,6 +32,7 @@ let environment = {
   },
   production: {
     debug: false,
+    googleAnayticsId: null,
     server: {
 <% if (props.target === 'web') { -%>
       url: '',
@@ -57,12 +62,7 @@ let config: IApplicationConfig = {
   supportedLanguages: [
     'en-US',
     'fr-FR'
-  ],
-
-  // Google Analytics account. Leave null to not have any analytics active.
-  // Typical values take the form 'UA-########-1'.
-  // Advice : this value may be handled by the gulp build task to use different accounts for development and production.
-  googleAnayticsId: null
+  ]
 
 };
 

--- a/generators/app/templates/sources/main/_main.constants.ts
+++ b/generators/app/templates/sources/main/_main.constants.ts
@@ -5,6 +5,7 @@ export interface IApplicationConfig {
   version: string;
   environment: IApplicationEnvironment;
   supportedLanguages: Array<string>;
+  analyticsAccount: string;
 }
 
 export interface IApplicationEnvironment {
@@ -56,7 +57,11 @@ let config: IApplicationConfig = {
   supportedLanguages: [
     'en-US',
     'fr-FR'
-  ]
+  ],
+
+  // Google Analytics account. Leave null to not have any analytics active.
+  // Typical values take the form 'UA-########-1'.
+  analyticsAccount: null
 
 };
 

--- a/generators/app/templates/sources/main/_main.constants.ts
+++ b/generators/app/templates/sources/main/_main.constants.ts
@@ -5,7 +5,7 @@ export interface IApplicationConfig {
   version: string;
   environment: IApplicationEnvironment;
   supportedLanguages: Array<string>;
-  analyticsAccount: string;
+  googleAnayticsId: string;
 }
 
 export interface IApplicationEnvironment {
@@ -61,7 +61,8 @@ let config: IApplicationConfig = {
 
   // Google Analytics account. Leave null to not have any analytics active.
   // Typical values take the form 'UA-########-1'.
-  analyticsAccount: null
+  // Advice : this value may be handled by the gulp build task to use different accounts for development and production.
+  googleAnayticsId: null
 
 };
 

--- a/generators/app/templates/sources/main/_main.run.ts
+++ b/generators/app/templates/sources/main/_main.run.ts
@@ -11,6 +11,7 @@ import {ILogger, LoggerService} from 'helpers/logger/logger';
  */
 function main($window: ng.IWindowService,
               $locale: ng.ILocaleService,
+              $location: ng.ILocationService,
               $rootScope: any,
               $state: angular.ui.IStateService,
 <% if (props.target !== 'web') { -%>
@@ -26,7 +27,8 @@ function main($window: ng.IWindowService,
 <% if (props.target !== 'web') { -%>
               logger: LoggerService,
 <% } -%>
-              restService: RestService) {
+              restService: RestService,
+              analyticsService: AnalyticsService) {
 
   /*
    * Root view model
@@ -82,6 +84,21 @@ function main($window: ng.IWindowService,
    */
   vm.$on('gettextLanguageChanged', () => {
     updateTitle($state.current.data ? $state.current.data.title : null);
+  });
+
+  /**
+   * Enables tracking by analytics service.
+   */
+  // HACK : ignore the first $viewContentLoaded event because it's actually fired once when uiView is instantiated,
+  // and then it's fired a second time after is has been linked. This is "by design" :-/
+  // (http://stackoverflow.com/questions/31000417/angular-js-viewcontentloaded-loading-twice-on-initial-homepage-load)
+  let loadedOnce = false;
+  vm.$on('$viewContentLoaded', function () {
+    if (!loadedOnce) {
+      loadedOnce = true;
+    } else if (analyticsService) {
+      analyticsService.trackPage($location.url());
+    }
   });
 
   init();

--- a/generators/app/templates/sources/main/_main.run.ts
+++ b/generators/app/templates/sources/main/_main.run.ts
@@ -1,6 +1,7 @@
 import app from 'main.module';
 import {IApplicationConfig} from 'main.constants';
 import {RestService} from 'helpers/rest/rest.service';
+import {AnalyticsService} from 'helpers/analytics/analytics.service';
 <% if (props.target !== 'web') { -%>
 import {ILogger, LoggerService} from 'helpers/logger/logger';
 <% } -%>

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -6,6 +6,7 @@ import {ILogger, LoggerService} from 'helpers/logger/logger';
  */
 export class AnalyticsService {
 
+  private logger: ILogger;
   private analyticsAreActive = false;
 
   constructor(private $window: ng.IWindowService,
@@ -17,27 +18,14 @@ export class AnalyticsService {
     this.init();
   }
 
-  private createGoogleAnalyticsObject(i, s, o, g, r, a?, m?) {
-    i.GoogleAnalyticsObject = r;
-    i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments);
-    };
-    i[r].l = new Date();
-    a = s.createElement(o);
-    m = s.getElementsByTagName(o)[0];
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m);
-  }
-
   /**
    * Tracks a page change in google analytics.
    * @param {String} url The url of the new page.
    */
   trackPage (url: string) {
     if (this.analyticsAreActive) {
-      var urlWithoutParams = url;
-      var split = url.split('?');
+      let urlWithoutParams = url;
+      let split = url.split('?');
       if (split.length > 1) {
         urlWithoutParams = split[0];
       }
@@ -57,13 +45,26 @@ export class AnalyticsService {
     }
   }
 
-  init(): void {
-    if (config.analyticsAccount !== null) {
-      var analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
+  private init(): void {
+    if (this.config.analyticsAccount !== null) {
+      let analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
       this.createGoogleAnalyticsObject(window, document, 'script', analyticsScriptUrl, 'googleAnalytics');
       this.$window.googleAnalytics('create', config.analyticsAccount, 'auto');
       this.analyticsAreActive = true;
     }
+  }
+
+  private createGoogleAnalyticsObject(i, s, o, g, r, a?, m?) {
+    i.GoogleAnalyticsObject = r;
+    i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments);
+    };
+    i[r].l = new Date();
+    a = s.createElement(o);
+    m = s.getElementsByTagName(o)[0];
+    a.async = 1;
+    a.src = g;
+    m.parentNode.insertBefore(a, m);
   }
 }
 

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -2,8 +2,10 @@ import app from 'main.module';
 import {ILogger, LoggerService} from 'helpers/logger/logger';
 import {IApplicationConfig} from 'main.constants';
 
+const analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
+
 interface IWindowWithAnalytics extends ng.IWindowService {
-  googleAnalytics: any;
+  ga: any;
 }
 
 /**
@@ -34,7 +36,7 @@ export class AnalyticsService {
       if (split.length > 1) {
         urlWithoutParams = split[0];
       }
-      this.$window.googleAnalytics('send', 'pageview', urlWithoutParams);
+      this.$window.ga('send', 'pageview', urlWithoutParams);
     }
   }
 
@@ -46,15 +48,19 @@ export class AnalyticsService {
    */
   trackEvent (category: string, action: string, label?: string) {
     if (this.analyticsAreActive) {
-      this.$window.googleAnalytics('send', 'event', category, action, label);
+      this.$window.ga('send', 'event', category, action, label);
+      let logMessage = 'Event tracked: ' + category + ' | ' + action;
+      if (label) {
+        logMessage += ' | ' + label;
+      }
+      this.logger.log(logMessage);
     }
   }
 
   private init(): void {
-    if (this.config.analyticsAccount !== null) {
-      let analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
-      this.createGoogleAnalyticsObject(window, document, 'script', analyticsScriptUrl, 'googleAnalytics');
-      this.$window.googleAnalytics('create', this.config.analyticsAccount, 'auto');
+    if (this.config.googleAnayticsId !== null) {
+      this.createGoogleAnalyticsObject(this.$window, document, 'script', analyticsScriptUrl, 'ga');
+      this.$window.ga('create', this.config.googleAnayticsId, 'auto');
       this.analyticsAreActive = true;
     }
   }

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -1,6 +1,6 @@
 import app from 'main.module';
 import {ILogger, LoggerService} from 'helpers/logger/logger';
-import {IApplicationConfig} from 'main.constants'
+import {IApplicationConfig} from 'main.constants';
 
 interface IWindowWithAnalytics extends ng.IWindowService {
   googleAnalytics: any;

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -1,6 +1,6 @@
 import app from 'main.module';
 import {ILogger, LoggerService} from 'helpers/logger/logger';
-import {IApplicationConfig} from 'main.constants';
+import {IApplicationEnvironment} from 'main.constants';
 
 const analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
 
@@ -17,7 +17,7 @@ export class AnalyticsService {
   private analyticsAreActive = false;
 
   constructor(private $window: IWindowWithAnalytics,
-              private config: IApplicationConfig,
+              private config: IApplicationEnvironment,
               logger: LoggerService) {
 
     this.logger = logger.getLogger('analyticsService');

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -1,5 +1,6 @@
 import app from 'main.module';
 import {ILogger, LoggerService} from 'helpers/logger/logger';
+import {IApplicationConfig} from 'main.constants'
 
 interface IWindowWithAnalytics extends ng.IWindowService {
   googleAnalytics: any;

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -1,6 +1,10 @@
 import app from 'main.module';
 import {ILogger, LoggerService} from 'helpers/logger/logger';
 
+interface IWindowWithAnalytics extends ng.IWindowService {
+  googleAnalytics: any;
+}
+
 /**
  * Analytics service: insert Google Analytics library in the page.
  */
@@ -9,7 +13,7 @@ export class AnalyticsService {
   private logger: ILogger;
   private analyticsAreActive = false;
 
-  constructor(private $window: ng.IWindowService,
+  constructor(private $window: IWindowWithAnalytics,
               private config: IApplicationConfig,
               logger: LoggerService) {
 
@@ -49,12 +53,12 @@ export class AnalyticsService {
     if (this.config.analyticsAccount !== null) {
       let analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
       this.createGoogleAnalyticsObject(window, document, 'script', analyticsScriptUrl, 'googleAnalytics');
-      this.$window.googleAnalytics('create', config.analyticsAccount, 'auto');
+      this.$window.googleAnalytics('create', this.config.analyticsAccount, 'auto');
       this.analyticsAreActive = true;
     }
   }
 
-  private createGoogleAnalyticsObject(i, s, o, g, r, a?, m?) {
+  private createGoogleAnalyticsObject(i: any, s: any, o: any, g: any, r: any, a?: any, m?: any) {
     i.GoogleAnalyticsObject = r;
     i[r] = i[r] || function () {
       (i[r].q = i[r].q || []).push(arguments);

--- a/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
+++ b/generators/app/templates/sources/main/helpers/analytics/analytics.service.ts
@@ -1,0 +1,70 @@
+import app from 'main.module';
+import {ILogger, LoggerService} from 'helpers/logger/logger';
+
+/**
+ * Analytics service: insert Google Analytics library in the page.
+ */
+export class AnalyticsService {
+
+  private analyticsAreActive = false;
+
+  constructor(private $window: ng.IWindowService,
+              private config: IApplicationConfig,
+              logger: LoggerService) {
+
+    this.logger = logger.getLogger('analyticsService');
+
+    this.init();
+  }
+
+  private createGoogleAnalyticsObject(i, s, o, g, r, a?, m?) {
+    i.GoogleAnalyticsObject = r;
+    i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments);
+    };
+    i[r].l = new Date();
+    a = s.createElement(o);
+    m = s.getElementsByTagName(o)[0];
+    a.async = 1;
+    a.src = g;
+    m.parentNode.insertBefore(a, m);
+  }
+
+  /**
+   * Tracks a page change in google analytics.
+   * @param {String} url The url of the new page.
+   */
+  trackPage (url: string) {
+    if (this.analyticsAreActive) {
+      var urlWithoutParams = url;
+      var split = url.split('?');
+      if (split.length > 1) {
+        urlWithoutParams = split[0];
+      }
+      this.$window.googleAnalytics('send', 'pageview', urlWithoutParams);
+    }
+  }
+
+  /**
+   * Sends a track event to google analytics.
+   * @param {String} category The category to be sent.
+   * @param {String} action The action to be sent.
+   * @param {String=} label The label to be sent.
+   */
+  trackEvent (category: string, action: string, label?: string) {
+    if (this.analyticsAreActive) {
+      this.$window.googleAnalytics('send', 'event', category, action, label);
+    }
+  }
+
+  init(): void {
+    if (config.analyticsAccount !== null) {
+      var analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
+      this.createGoogleAnalyticsObject(window, document, 'script', analyticsScriptUrl, 'googleAnalytics');
+      this.$window.googleAnalytics('create', config.analyticsAccount, 'auto');
+      this.analyticsAreActive = true;
+    }
+  }
+}
+
+app.service('analyticsService', AnalyticsService);


### PR DESCRIPTION
Added analytics service in /helpers. This services supports basic page tracking (automatically triggered on view change, so the function never has to be called manually) and event tracking by calling the provided function.