### PR TITLE
Use webpack-stream-fixed

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -74,7 +74,7 @@
     "typescript": "^2.0.3",
     "typings": "^2.1.0",
     "uglify-save-license": "~0.4.1",
-    "webpack-stream": "^3.1.0",
+    "webpack-stream-fixed": "^3.2.2",
     "wiredep": "^4.0.0"
   },
   "engines": {

--- a/generators/app/templates/gulp/scripts.js
+++ b/generators/app/templates/gulp/scripts.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var gulp = require('gulp');
 var conf = require('../gulpfile.config');
-var webpack = require('webpack-stream');
+var webpack = require('webpack-stream-fixed');
 var browserSync = require('browser-sync');
 
 var $ = require('gulp-load-plugins')();


### PR DESCRIPTION
Use webpack-stream-fixed instead of webpack-stream to not break stream if a TS compilation error occurs.

For details, see https://github.com/shama/webpack-stream/pull/126